### PR TITLE
Tweak the build system more [GRF-6059]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,9 @@ boto3 = "*"
 google-cloud-storage = "*"
 python-magic = "*"
 
+# General
+boltons = "*"
+
 
 [tool.poetry.group.dev.dependencies]
 # Tests
@@ -212,8 +215,8 @@ file = "README.nohtml"
 content-type = "text/markdown"
 
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
-build-backend = "setuptools.build_meta"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.setuptools]
 py-modules = [

--- a/sematic/db/migrations/20220930014400_migrate_exception_data.py
+++ b/sematic/db/migrations/20220930014400_migrate_exception_data.py
@@ -35,7 +35,7 @@ def down():
         run_id_exception_json_pairs = conn.execute(
             text(
                 "SELECT id, exception_json FROM runs "
-                "WHERE exception_json IS NOT NULL AND exception_json IS NOT 'null';"
+                "WHERE exception_json IS NOT NULL AND exception_json != 'null';"
             )
         )
 


### PR DESCRIPTION
# Description
We're hitting some issues after pointing `graft` to the tip of `graft/sematic/main` with the changes added in #5.

1. We can't install the `sematic` package
2. We're missing migration files, breaking Sematic DB initialization

This PR addresses the first and _potentially_ addresses the second. For the first, I tweaked our fork to use `poetry` instead of `setuptools` as the builder. The reason I say it potentially addresses the second is that previously we've had things work just fine when using the `poetry`-based package builder, so that play out again?

As part of this PR I also fix a bug in one of the Alembic migration files which uses bad PostgreSQL syntax for a rollback step.