### PR TITLE
Fix parametrized generics for dataclasses [GRF-6059]

### DIFF
--- a/sematic/types/serialization.py
+++ b/sematic/types/serialization.py
@@ -15,6 +15,7 @@ from enum import Enum
 
 # Third-party
 import cloudpickle  # type: ignore
+from typing_extensions import get_original_bases
 
 # Sematic
 from sematic.types.generic_type import GenericType
@@ -30,6 +31,7 @@ from sematic.types.registry import (
     is_sematic_parametrized_generic_type,
     is_supported_type_annotation,
 )
+from sematic.utils.types import resolve_type
 
 
 # VALUE SERIALIZATION
@@ -193,7 +195,7 @@ def type_from_json_encodable(json_encodable: typing.Any) -> typing.Any:
 def _type_repr(
     type_: typing.Any,
 ) -> typing.Tuple[str, str, typing.Dict[str, typing.Any]]:
-    return (_get_category(type_), _get_key(type_), _get_parameters(type_))
+    return _get_category(type_), _get_key(type_), _get_parameters(type_)
 
 
 _BUILTINS = (float, int, str, bool, type(None), bytes)
@@ -271,11 +273,11 @@ def _get_parameters(type_: typing.Any) -> typing.Dict[str, typing.Any]:
         return {"args": [_parameter_repr(arg) for arg in typing.get_args(type_)]}
 
     if _is_dataclass(type_):
+        field_names = [field.name for field in dataclasses.fields(type_)]
         return {
             "import_path": type_.__module__,
             "fields": {
-                name: _parameter_repr(field.type)
-                for name, field in type_.__dataclass_fields__.items()
+                name: _parameter_repr(resolve_type(type_, name)) for name in field_names
             },
         }
 
@@ -320,7 +322,20 @@ def _parameter_repr(value: typing.Any) -> typing.Any:
 
 def _populate_registry(type_: typing.Any, registry: typing.Dict[str, typing.Any]) -> None:
     def _include_in_registry(t) -> bool:
+        if _has_unparametrized_type_vars(t):
+            return False
         return t not in (object, abc.ABC, GenericType)
+
+    def _has_unparametrized_type_vars(cls: type):
+        try:
+            return any(
+                isinstance(T, typing.TypeVar)
+                for base in get_original_bases(cls)
+                for T in typing.get_args(base)
+            )
+        except TypeError:
+            # Then we're dealing with a parametrized GenericAlias, like dict[str, str]
+            return False
 
     if not _include_in_registry(type_):
         return
@@ -333,7 +348,10 @@ def _populate_registry(type_: typing.Any, registry: typing.Dict[str, typing.Any]
 
     if _is_dataclass(type_):
         _populate_registry_from_parameters(
-            {name: field.type for name, field in type_.__dataclass_fields__.items()},
+            {
+                name: resolve_type(type_, name)
+                for name in type_.__dataclass_fields__.keys()
+            },
             registry,
         )
 

--- a/sematic/types/types/dataclass.py
+++ b/sematic/types/types/dataclass.py
@@ -34,6 +34,7 @@ from sematic.types.serialization import (
     value_from_json_encodable,
     value_to_json_encodable,
 )
+from sematic.utils.types import resolve_type
 
 
 @register_safe_cast(DataclassKey)
@@ -57,8 +58,8 @@ def _safe_cast_dataclass(value: Any, type_: Any) -> Tuple[Any, Optional[str]]:
         # Otherwise we make sure the subclass is conserved, including
         # potential additional fields.
         cast_value = copy.deepcopy(value)
-
-    for name, field in type_.__dataclass_fields__.items():
+    field_names = [field.name for field in dataclasses.fields(type_)]
+    for name in field_names:
         try:
             # First we attempt to access the property
             field_value = getattr(value, name)
@@ -70,8 +71,8 @@ def _safe_cast_dataclass(value: Any, type_: Any) -> Tuple[Any, Optional[str]]:
                 return None, "Cannot cast {} to {}: Field {} is missing".format(
                     repr(value), type_, repr(name)
                 )
-
-        cast_field, error = safe_cast(field_value, field.type)
+        field_type = resolve_type(type_, name)
+        cast_field, error = safe_cast(field_value, field_type)
         if error is not None:
             return None, "Cannot cast field '{}' of {} to {}: {}".format(
                 name, repr(value), type_, error
@@ -108,7 +109,9 @@ def _can_cast_to_dataclass(from_type: Any, to_type: Any) -> Tuple[bool, Optional
         return False, "{}: missing fields: {}".format(prefix, repr(missing_fields))
 
     for name, field in to_fields.items():
-        can_cast, error = can_cast_type(from_fields[name].type, field.type)
+        from_attr_type = resolve_type(cls=from_type, attribute=name)
+        to_attr_type = resolve_type(cls=to_type, attribute=name)
+        can_cast, error = can_cast_type(from_attr_type, to_attr_type)
         if not can_cast:
             return False, "{}: field {} cannot cast: {}".format(prefix, repr(name), error)
 
@@ -136,11 +139,9 @@ def _dataclass_from_json_encodable(value: Any, type_: Any) -> Any:
         )
 
     kwargs = {}
-
-    fields: Dict[str, dataclasses.Field] = root_type.__dataclass_fields__
-
-    for name, field in fields.items():
-        field_type = field.type
+    field_names = [field.name for field in dataclasses.fields(root_type)]
+    for name in field_names:
+        field_type = resolve_type(root_type, name)
         if name in types:
             field_type = type_from_json_encodable(types[name])
 
@@ -179,7 +180,7 @@ def _serialize_dataclass(serializer: Callable, value: Any, _) -> SummaryOutput:
         # The actual value type can be different from the field type if
         # the value is an instance of a subclass
         value_type = type(field_value)
-        field_type = value_serialization_type = field.type
+        field_type = value_serialization_type = resolve_type(type_, name)
 
         # Only if the value type is different (e.g. subclass) do we persist the type
         # serialization
@@ -245,19 +246,20 @@ def fromdict(dataclass_type: Type[T], as_dict: Dict[str, Any]) -> T:
         if not field.init:
             continue
         dict_value = as_dict[name]
-        if dataclasses.is_dataclass(field.type):
-            kwargs[name] = fromdict(field.type, dict_value)  # type: ignore
+        field_type = resolve_type(dataclass_type, name)
+        if dataclasses.is_dataclass(field_type):
+            kwargs[name] = fromdict(field_type, dict_value)  # type: ignore
             continue
-        if get_origin(field.type) is list:
-            element_type = get_args(field.type)[0]
+        if get_origin(field_type) is list:
+            element_type = get_args(field_type)[0]
             if dataclasses.is_dataclass(element_type):
                 kwargs[name] = [  # type: ignore
                     fromdict(element_type, element)  # type: ignore
                     for element in dict_value
                 ]
                 continue
-        if get_origin(field.type) is dict:
-            value_type = get_args(field.type)[1]
+        if get_origin(field_type) is dict:
+            value_type = get_args(field_type)[1]
             if dataclasses.is_dataclass(value_type):
                 kwargs[name] = {  # type: ignore
                     key: fromdict(value_type, value)  # type: ignore

--- a/sematic/types/types/tests/test_dataclass_generic.py
+++ b/sematic/types/types/tests/test_dataclass_generic.py
@@ -1,0 +1,188 @@
+"""Module providing tests of Dataclass support for Generic dataclasses."""
+
+# Standard Library
+import re
+
+# Third-party
+import sys
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+import pytest
+from typing_extensions import get_original_bases
+
+# Sematic
+from sematic.types.casting import can_cast_type, safe_cast
+from sematic.types.serialization import (
+    type_from_json_encodable,
+    type_to_json_encodable,
+)
+
+
+T = TypeVar("T")
+
+
+@dataclass
+class HasGeneric(Generic[T]):
+    x: T
+
+
+@dataclass
+class DerivedIntHasGeneric(HasGeneric[int]):
+    pass
+
+
+@dataclass
+class DerivedFloatHasGeneric(HasGeneric[float]):
+    pass
+
+
+@dataclass
+class DerivedStrHasGeneric(HasGeneric[str]):
+    pass
+
+
+@dataclass
+class DerivedIntListHasGeneric(HasGeneric[list[int]]):
+    pass
+
+
+@pytest.mark.parametrize(
+    "from_type, to_type, expected_can_cast, expected_error",
+    (
+        # When the underlying types can cast to one another, it's fine
+        (
+            DerivedIntHasGeneric,
+            DerivedFloatHasGeneric,
+            True,
+            None,
+        ),
+        (
+            DerivedFloatHasGeneric,
+            DerivedIntHasGeneric,
+            True,
+            None,
+        ),
+        # But if the types can't cast, it breaks
+        (
+            DerivedFloatHasGeneric,
+            DerivedStrHasGeneric,
+            False,
+            (
+                r"Cannot cast.*DerivedFloatHasGeneric.*to.*DerivedStrHasGeneric.*"
+                r"field 'x' cannot cast.*float.*cannot cast.*str"
+            ),
+        ),
+        (
+            DerivedIntHasGeneric,
+            DerivedIntListHasGeneric,
+            False,
+            (
+                r"Cannot cast.*DerivedIntHasGeneric.*to.*DerivedIntListHasGeneric.*"
+                r"field 'x' cannot cast.*int.*to list.*int.*"
+            ),
+        ),
+    ),
+)
+def test_can_cast_type(from_type, to_type, expected_can_cast, expected_error):
+    can_cast, error = can_cast_type(from_type, to_type)
+    assert can_cast is expected_can_cast, error
+    if expected_error is None:
+        assert error is None
+    else:
+        assert re.match(expected_error, error)
+
+
+@pytest.mark.parametrize(
+    "value, type_, expected_type, expected_value, expected_error",
+    (
+        # When the underlying types can cast to one another, it's fine
+        (
+            DerivedIntHasGeneric(x=1),
+            DerivedFloatHasGeneric,
+            DerivedFloatHasGeneric,
+            DerivedFloatHasGeneric(x=1.0),
+            None,
+        ),
+        (
+            DerivedFloatHasGeneric(x=1.0),
+            DerivedIntHasGeneric,
+            DerivedIntHasGeneric,
+            DerivedIntHasGeneric(x=1),
+            None,
+        ),
+        # But if the types can't cast, it breaks
+        (
+            DerivedFloatHasGeneric(x=1),
+            DerivedStrHasGeneric,
+            DerivedStrHasGeneric,
+            None,
+            (
+                r"Cannot cast field 'x' of DerivedFloatHasGeneric.*to.*"
+                r"DerivedStrHasGeneric.*Cannot cast 1 to.*str"
+            ),
+        ),
+        (
+            DerivedIntHasGeneric(x=1),
+            DerivedIntListHasGeneric,
+            DerivedIntListHasGeneric,
+            None,
+            (
+                r"Cannot cast field 'x' of DerivedIntHasGeneric.*to.*"
+                r"DerivedIntListHasGeneric.*1 not an iterable"
+            ),
+        ),
+    ),
+)
+def test_safe_cast(
+    value: Any, type_: type, expected_type: type, expected_value: Any, expected_error: str
+):
+    cast_value, error = safe_cast(value, type_)
+    if expected_error is None:
+        assert isinstance(cast_value, expected_type), error
+        assert cast_value == expected_value
+        assert error is None
+    else:
+        assert error is not None
+        assert re.match(expected_error, error)
+
+
+def test_type_to_json_encodable():
+    """Test casting a dataclass to JSON-encodable."""
+    result = type_to_json_encodable(DerivedIntHasGeneric)
+    category, key, parameters = result["type"]
+    assert category == "dataclass"
+    assert key == DerivedIntHasGeneric.__name__
+    expected_parameters = {
+        "import_path": DerivedIntHasGeneric.__module__,
+        "fields": {"x": {"type": ("builtin", "int", {})}},
+    }
+    assert parameters == expected_parameters
+    registry = result["registry"]
+    major, minor, *_ = sys.version_info
+    if minor >= 10:
+        for base in get_original_bases(DerivedIntHasGeneric):
+            assert base.__name__ not in registry
+
+
+@dataclass
+class HasDerivedGeneric:
+    derived_generic: DerivedIntHasGeneric
+
+
+GENERIC_TYPES_TO_TEST = (
+    DerivedIntHasGeneric,
+    DerivedFloatHasGeneric,
+    DerivedStrHasGeneric,
+    DerivedIntListHasGeneric,
+    HasDerivedGeneric,
+)
+
+
+@pytest.mark.parametrize(
+    "type_",
+    GENERIC_TYPES_TO_TEST,
+)
+def test_type_from_json_encodable(type_: type):
+    json_encodable = type_to_json_encodable(type_)
+    assert type_from_json_encodable(json_encodable) is type_

--- a/sematic/utils/tests/test_types.py
+++ b/sematic/utils/tests/test_types.py
@@ -1,0 +1,49 @@
+# Standard Library
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+# Third-party
+import pytest
+
+# Sematic
+from sematic.utils.types import resolve_type
+
+
+def test_resolve_type():
+    """Test the resolve_type utility."""
+
+    T = TypeVar("T")
+
+    @dataclass
+    class A(Generic[T]):
+        val: T
+
+        def test(self, a: T) -> T:
+            return self.val
+
+    @dataclass
+    class B(A[int]):
+        def test(self, a: int) -> int:
+            return a + self.val
+
+    @dataclass
+    class C(A[A[int]]):
+        pass
+
+    @dataclass
+    class Concrete:
+        x: int
+
+    assert resolve_type(B, "val") is int
+    assert resolve_type(C, "val") is A[int]
+    assert resolve_type(Concrete, "x") is int
+    for cls, attr_name, match in (
+        (
+            A,
+            "val",
+            "The annotation for 'val' has not been parametrized",
+        ),
+        (Concrete, "y", "The class 'Concrete' does not have the 'y' attribute"),
+    ):
+        with pytest.raises(ValueError, match=match):
+            resolve_type(cls, attr_name)

--- a/sematic/utils/types.py
+++ b/sematic/utils/types.py
@@ -1,5 +1,15 @@
 # Standard Library
-from typing import Any, Optional
+from typing import (
+    Any,
+    Generic,
+    Optional,
+    TypeVar,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+from typing_extensions import get_original_bases
 
 
 def as_bool(value: Optional[Any]) -> bool:
@@ -41,3 +51,36 @@ def strtobool(value):
         return _MAP[str(value).lower()]
     except KeyError:
         raise ValueError('"{}" is not a valid bool value'.format(value))
+
+
+def resolve_type(cls: type, attribute: str):
+    """Resolve the type of an attribute on an input class.
+
+    Handles situation where attribute is a TypeVar.
+    """
+    # Get the type hints for the class
+    type_hints = get_type_hints(cls)
+    try:
+        field_type = type_hints[attribute]
+    except KeyError:
+        error_msg = (
+            f"The class '{cls.__name__}' does not have the '{attribute}' attribute"
+        )
+        raise ValueError(error_msg)
+    # Check if the type is a TypeVar
+    if isinstance(field_type, TypeVar):
+        # Iterate through the bases to find the matching origin and substitution
+        for base in get_original_bases(cls):
+            origin = get_origin(base)
+            if origin is None:
+                raise ValueError(f"Found no origin for the base: {base.__name__}")
+            elif origin is Generic:
+                error_msg = f"The annotation for '{attribute}' has not been parametrized"
+                raise ValueError(error_msg)
+            else:
+                type_args = get_args(base)
+                # Map TypeVars to their actual types
+                type_var_mapping = dict(zip(origin.__parameters__, type_args))
+                if field_type in type_var_mapping:
+                    return type_var_mapping[field_type]
+    return field_type

--- a/sematic/utils/types.py
+++ b/sematic/utils/types.py
@@ -58,7 +58,7 @@ def resolve_type(cls: type, attribute: str):
 
     Handles situation where attribute is a TypeVar.
     """
-    # Get the type hints for the class
+    # Extract the attribute's type hint
     type_hints = get_type_hints(cls)
     try:
         field_type = type_hints[attribute]
@@ -67,9 +67,9 @@ def resolve_type(cls: type, attribute: str):
             f"The class '{cls.__name__}' does not have the '{attribute}' attribute"
         )
         raise ValueError(error_msg)
-    # Check if the type is a TypeVar
+    # And if it's a TypeVar....
     if isinstance(field_type, TypeVar):
-        # Iterate through the bases to find the matching origin and substitution
+        # Iterate through the bases to find the matching original type
         for base in get_original_bases(cls):
             origin = get_origin(base)
             if origin is None:


### PR DESCRIPTION
# Description
Currently, if you have a `@dataclass` in Sematic where one of the attributes is a parametrized `Generic[T]` class, Sematic will complain. For example, on `graft/sematic/main`
```python
from dataclasses import dataclass
from typing import Generic, TypeVar
import sematic

JS = TypeVar("JS")

@dataclass
class A(Generic[JS]):
    val: JS

    def test(self, a: JS) -> JS:
        pass

@dataclass
class B(A[int]):
    def test(self, a: int) -> int:
        return a + self.val


@sematic.func
def gen(inp: B) -> int:
    return inp.test(1)

b = B(val=1)
sematic.SilentRunner().run(gen(b))

TypeError: Invalid input type for argument 'inp' when calling '__main__.gen'. Cannot cast B(val=1) to <class '__main__.B'>: Cannot cast field 'val' of B(val=1) to <class '__main__.B'>: Type 'JS' is not a valid Sematic type: Expected a Sematic-supported type here, but got: ~JS. Please refer to the Sematic docs about supported types: https://docs.sematic.dev/type-support/type-support#what-types-are-supported
```

The problem is that Sematic is directly pulling `field.type` which for classes `A`/`B` above, returns `JS` for `val`. Instead Sematic needs to correctly resolve the `JS` (or other `TypeVar`s) against the arguments to the `Generic` class. This PR fixes this issue by introducing a `resolve_type` method to handle this scenario.
## Testing
```bash
$ pytest sematic/types/types/tests/ sematic/utils/tests/test_types.py
```
### Manual Testing
```python
In [1]: from dataclasses import dataclass
   ...: from typing import Generic, TypeVar
   ...: import sematic
   ...: 
   ...: JS = TypeVar("JS")
   ...: 
   ...: @dataclass
   ...: class A(Generic[JS]):
   ...:     val: JS
   ...: 
   ...:     def test(self, a: JS) -> JS:
   ...:         pass
   ...: 
   ...: @dataclass
   ...: class B(A[int]):
   ...:     def test(self, a: int) -> int:
   ...:         return a + self.val
   ...: 
   ...: 
   ...: @sematic.func
   ...: def gen(inp: B) -> int:
   ...:     return inp.test(1)
   ...: 
   ...: b = B(val=1)
   ...: sematic.SilentRunner().run(gen(b))
Out[1]: 2
```