### PR TITLE
Fix resolve_type for containers of generic types [GRF-6059]

### DIFF
--- a/sematic/types/types/tests/test_dataclass_generic.py
+++ b/sematic/types/types/tests/test_dataclass_generic.py
@@ -20,6 +20,7 @@ from sematic.types.serialization import (
 
 
 T = TypeVar("T")
+U = TypeVar("U")
 
 
 @dataclass
@@ -44,6 +45,23 @@ class DerivedStrHasGeneric(HasGeneric[str]):
 
 @dataclass
 class DerivedIntListHasGeneric(HasGeneric[list[int]]):
+    pass
+
+
+@dataclass
+class HasGenericContainers(Generic[T, U]):
+    items_list: list[T]
+    items_tuple: tuple[T]
+    items_set: set[U]
+
+
+@dataclass
+class DerivedIntFloat(HasGenericContainers[int, float]):
+    pass
+
+
+@dataclass
+class DerivedIntStr(HasGenericContainers[int, str]):
     pass
 
 
@@ -80,6 +98,16 @@ class DerivedIntListHasGeneric(HasGeneric[list[int]]):
             (
                 r"Cannot cast.*DerivedIntHasGeneric.*to.*DerivedIntListHasGeneric.*"
                 r"field 'x' cannot cast.*int.*to list.*int.*"
+            ),
+        ),
+        (DerivedIntFloat, DerivedIntFloat, True, None),
+        (
+            DerivedIntFloat,
+            DerivedIntStr,
+            False,
+            (
+                r"Cannot cast.*DerivedIntFloat.*DerivedIntStr.*"
+                r"Can't cast set.*float.*to set.*str.*float.*cannot cast to str"
             ),
         ),
     ),

--- a/sematic/utils/tests/test_types.py
+++ b/sematic/utils/tests/test_types.py
@@ -1,4 +1,5 @@
 # Standard Library
+import sys
 from dataclasses import dataclass
 from typing import Generic, TypeVar, Union
 
@@ -81,3 +82,19 @@ def test_resolve_type_for_container_types():
     assert resolve_type(IntFloat, "items_set") == set[int]
     assert resolve_type(IntFloat, "maps") == dict[int, float]
     assert resolve_type(Nested, "maps") == dict[int, HasContainers[int, float]]
+
+
+major, minor, *_ = sys.version_info
+SKIP_CONDITION = (major, minor) <= (3, 9)
+
+
+@pytest.mark.skipif(
+    condition=SKIP_CONDITION,
+    reason="This test only makes sense for Python 3.10 and higher",
+)
+def test_resolve_type_for_modern_annotations():
+    @dataclass
+    class HasModernUnion:
+        union: int | str
+
+    assert resolve_type(HasModernUnion, "union") is Union[int, str]

--- a/sematic/utils/tests/test_types.py
+++ b/sematic/utils/tests/test_types.py
@@ -1,6 +1,6 @@
 # Standard Library
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Union
 
 # Third-party
 import pytest
@@ -17,28 +17,35 @@ def test_resolve_type_for_basic_type():
     """Test the resolve_type utility."""
 
     @dataclass
-    class A(Generic[T]):
+    class A(Generic[T, U]):
         val: T
+        union_val: Union[T, U]
 
         def test(self, a: T) -> T:
             return self.val
 
     @dataclass
-    class B(A[int]):
+    class B(A[int, float]):
         def test(self, a: int) -> int:
             return a + self.val
 
     @dataclass
-    class C(A[A[int]]):
+    class C(A[A[int, float], float]):
         pass
 
     @dataclass
     class Concrete:
         x: int
 
+    @dataclass
+    class HasUnion:
+        union: Union[int, str]
+
     assert resolve_type(B, "val") is int
-    assert resolve_type(C, "val") is A[int]
+    assert resolve_type(B, "union_val") is Union[int, float]
+    assert resolve_type(C, "val") is A[int, float]
     assert resolve_type(Concrete, "x") is int
+    assert resolve_type(HasUnion, "union") is Union[int, str]
     for cls, attr_name, match in (
         (
             A,

--- a/sematic/utils/tests/test_types.py
+++ b/sematic/utils/tests/test_types.py
@@ -9,10 +9,12 @@ import pytest
 from sematic.utils.types import resolve_type
 
 
-def test_resolve_type():
-    """Test the resolve_type utility."""
+T = TypeVar("T")
+U = TypeVar("U")
 
-    T = TypeVar("T")
+
+def test_resolve_type_for_basic_type():
+    """Test the resolve_type utility."""
 
     @dataclass
     class A(Generic[T]):
@@ -47,3 +49,28 @@ def test_resolve_type():
     ):
         with pytest.raises(ValueError, match=match):
             resolve_type(cls, attr_name)
+
+
+def test_resolve_type_for_container_types():
+    """Test the resolve_type utility."""
+
+    @dataclass
+    class HasContainers(Generic[T, U]):
+        items_list: list[T]
+        items_tuple: tuple[T]
+        items_set: set[T]
+        maps: dict[T, U]
+
+    @dataclass
+    class IntFloat(HasContainers[int, float]):
+        pass
+
+    @dataclass
+    class Nested(HasContainers[int, HasContainers[int, float]]):
+        pass
+
+    assert resolve_type(IntFloat, "items_list") == list[int]
+    assert resolve_type(IntFloat, "items_tuple") == tuple[int]
+    assert resolve_type(IntFloat, "items_set") == set[int]
+    assert resolve_type(IntFloat, "maps") == dict[int, float]
+    assert resolve_type(Nested, "maps") == dict[int, HasContainers[int, float]]

--- a/sematic/utils/types.py
+++ b/sematic/utils/types.py
@@ -1,5 +1,4 @@
 # Standard Library
-import types
 from typing import (
     Any,
     Generic,
@@ -11,7 +10,6 @@ from typing import (
     get_type_hints,
 )
 
-from boltons.typeutils import issubclass
 from typing_extensions import get_original_bases
 
 
@@ -78,7 +76,7 @@ def _resolve_generic_type(
 ) -> Union[type, TypeVar]:
     origin = get_origin(type_)
     if origin is not None:  # It's a generic like list, dict, etc.
-        if issubclass(origin, types.UnionType):
+        if origin is Union:
             resolved_args = tuple(
                 _resolve_generic_type(cls, arg, attribute) for arg in get_args(type_)
             )

--- a/sematic/utils/types.py
+++ b/sematic/utils/types.py
@@ -1,4 +1,5 @@
 # Standard Library
+import types
 from typing import (
     Any,
     Generic,
@@ -10,6 +11,7 @@ from typing import (
     get_type_hints,
 )
 
+from boltons.typeutils import issubclass
 from typing_extensions import get_original_bases
 
 
@@ -76,6 +78,11 @@ def _resolve_generic_type(
 ) -> Union[type, TypeVar]:
     origin = get_origin(type_)
     if origin is not None:  # It's a generic like list, dict, etc.
+        if issubclass(origin, types.UnionType):
+            resolved_args = tuple(
+                _resolve_generic_type(cls, arg, attribute) for arg in get_args(type_)
+            )
+            return Union[resolved_args]
         args = tuple(
             _resolve_generic_type(cls=cls, type_=arg, attribute=attribute)
             for arg in get_args(type_)

--- a/sematic/utils/types.py
+++ b/sematic/utils/types.py
@@ -4,6 +4,7 @@ from typing import (
     Generic,
     Optional,
     TypeVar,
+    Union,
     get_args,
     get_origin,
     get_type_hints,
@@ -67,20 +68,35 @@ def resolve_type(cls: type, attribute: str):
             f"The class '{cls.__name__}' does not have the '{attribute}' attribute"
         )
         raise ValueError(error_msg)
-    # And if it's a TypeVar....
-    if isinstance(field_type, TypeVar):
-        # Iterate through the bases to find the matching original type
+    return _resolve_generic_type(cls=cls, type_=field_type, attribute=attribute)
+
+
+def _resolve_generic_type(
+    cls: type, type_: Union[type, TypeVar], attribute: str
+) -> Union[type, TypeVar]:
+    origin = get_origin(type_)
+    if origin is not None:  # It's a generic like list, dict, etc.
+        args = tuple(
+            _resolve_generic_type(cls=cls, type_=arg, attribute=attribute)
+            for arg in get_args(type_)
+        )
+        return origin[args] if args else origin
+    elif isinstance(type_, TypeVar):  # Resolve TypeVar
+        # Resolve the TypeVar from the class's __orig_bases__
         for base in get_original_bases(cls):
-            origin = get_origin(base)
-            if origin is None:
+            base_origin = get_origin(base)
+            if base_origin is None:
                 raise ValueError(f"Found no origin for the base: {base.__name__}")
-            elif origin is Generic:
+            elif base_origin is Generic:
                 error_msg = f"The annotation for '{attribute}' has not been parametrized"
                 raise ValueError(error_msg)
             else:
                 type_args = get_args(base)
-                # Map TypeVars to their actual types
-                type_var_mapping = dict(zip(origin.__parameters__, type_args))
-                if field_type in type_var_mapping:
-                    return type_var_mapping[field_type]
-    return field_type
+                type_var_mapping = dict(zip(base_origin.__parameters__, type_args))
+                if type_ in type_var_mapping:
+                    return type_var_mapping[type_]
+        # Unresolved TypeVar
+        return type_
+    else:
+        # Non-generic type (e.g., int, str)
+        return type_

--- a/sematic/utils/types.py
+++ b/sematic/utils/types.py
@@ -5,6 +5,7 @@ from typing import (
     Optional,
     TypeVar,
     Union,
+    cast,
     get_args,
     get_origin,
     get_type_hints,
@@ -80,7 +81,7 @@ def _resolve_generic_type(
             resolved_args = tuple(
                 _resolve_generic_type(cls, arg, attribute) for arg in get_args(type_)
             )
-            return Union[resolved_args]
+            return cast(type, Union[resolved_args])
         args = tuple(
             _resolve_generic_type(cls=cls, type_=arg, attribute=attribute)
             for arg in get_args(type_)

--- a/sematic/utils/types.py
+++ b/sematic/utils/types.py
@@ -1,4 +1,6 @@
 # Standard Library
+import sys
+import types
 from typing import (
     Any,
     Generic,
@@ -11,6 +13,7 @@ from typing import (
     get_type_hints,
 )
 
+from boltons.typeutils import issubclass
 from typing_extensions import get_original_bases
 
 
@@ -77,16 +80,14 @@ def _resolve_generic_type(
 ) -> Union[type, TypeVar]:
     origin = get_origin(type_)
     if origin is not None:  # It's a generic like list, dict, etc.
-        if origin is Union:
-            resolved_args = tuple(
-                _resolve_generic_type(cls, arg, attribute) for arg in get_args(type_)
-            )
-            return cast(type, Union[resolved_args])
-        args = tuple(
+        resolved_args = tuple(
             _resolve_generic_type(cls=cls, type_=arg, attribute=attribute)
             for arg in get_args(type_)
         )
-        return origin[args] if args else origin
+        major, minor, *_ = sys.version_info
+        if (major, minor) >= (3, 10) and issubclass(origin, types.UnionType):
+            return cast(type, Union[resolved_args])
+        return origin[resolved_args] if resolved_args else origin
     elif isinstance(type_, TypeVar):  # Resolve TypeVar
         # Resolve the TypeVar from the class's __orig_bases__
         for base in get_original_bases(cls):


### PR DESCRIPTION
# Description
The function added in #7 was missing some corner cases: in particular, it needs to be able to handle containers of generic types. This PR fixes it.
## Testing
```bash
$ pytest \
    sematic/utils/tests/test_types.py \
    sematic/types/types/tests/test_dataclass_generic.py
```